### PR TITLE
🧹chore: adding vue extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
       },
 
       // Add the IDs of extensions you want installed when the container is created.
-      "extensions": ["ms-python.python", "ms-python.vscode-pylance"]
+      "extensions": ["ms-python.python", "ms-python.vscode-pylance", "Vue.volar"]
     }
   },
 


### PR DESCRIPTION
So VSCode will have it handy ([link to ext](https://marketplace.visualstudio.com/items?itemName=Vue.volar))